### PR TITLE
Introduce training loss

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.1
+current_version = 0.0.2
 commit = True
 tag = True
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include requirements.txt
+include requirements_dev.txt

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@
   ·
   <a href="https://serre-lab.github.io/harmonization/models">Models zoo</a>
   ·
-  <a href="todo">Evaluate your model</a>
+  <a href="todo">Tutorials</a>
 </p>
 
 ## Paper summary

--- a/docs/results.md
+++ b/docs/results.md
@@ -96,7 +96,7 @@ window.addEventListener('DOMContentLoaded', function() {
         e.returnValue = false;
     }
 
-    const NB_IMAGES = 200
+    const NB_IMAGES = 100
     const SCROLL_POWER = 50
 
     const GALLERY_DATA = [

--- a/harmonization/__init__.py
+++ b/harmonization/__init__.py
@@ -6,7 +6,7 @@ The goal of this project is to provide a simple interface to align the latest
 vision models with human vision.
 """
 
-__version__ = '0.0.1'
+__version__ = '0.0.2'
 
 from . import evaluation
 from . import training

--- a/harmonization/training/__init__.py
+++ b/harmonization/training/__init__.py
@@ -1,0 +1,5 @@
+"""
+Module dedicated to the training of harmonized models
+"""
+
+from .loss import standardize_cut, pyramidal_mse_with_tokens, harmonizer_loss

--- a/harmonization/training/loss.py
+++ b/harmonization/training/loss.py
@@ -1,0 +1,165 @@
+"""
+Harmonization loss
+"""
+
+import tensorflow as tf
+from .pyramid import pyramidal_representation
+
+
+Cross_entropy = tf.keras.losses.CategoricalCrossentropy(from_logits=True,
+                                                        reduction=tf.keras.losses.Reduction.NONE,
+                                                        label_smoothing=0.1)
+
+
+def standardize_cut(heatmaps, axes=(1, 2), epsilon=1e-5):
+    """
+    Standardize the heatmaps (zero mean, unit variance) and apply ReLU.
+
+    Parameters
+    ----------
+    heatmaps : tf.Tensor
+        The heatmaps to standardize.
+    axes : tuple
+        The axes to compute the mean and variance.
+    epsilon : float
+        A small value to avoid division by zero.
+
+    Returns
+    -------
+    tf.Tensor
+        The positive part of the standardized heatmaps.
+    """
+    means = tf.reduce_mean(heatmaps, axes, keepdims=True)
+    stds = tf.math.reduce_std(heatmaps, axes, keepdims=True)
+
+    heatmaps = heatmaps - means
+    heatmaps = heatmaps / (stds + epsilon)
+
+    heatmaps = tf.nn.relu(heatmaps)
+
+    return heatmaps
+
+
+def _mse_with_tokens(heatmaps_a, heatmaps_b, tokens):
+    """
+    Compute the MSE between two set of heatmaps, weighted by the tokens.
+
+    Parameters
+    ----------
+    heatmap_a : tf.Tensor
+        The first heatmap.
+    heatmap_b : tf.Tensor
+        The second heatmap.
+    token : tf.Tensor
+        The token to weight the MSE.
+
+    Returns
+    -------
+    tf.Tensor
+        The weighted MSE.
+    """
+    return tf.reduce_mean(tf.square(heatmaps_a - heatmaps_b) * tokens[:, None, None, None])
+
+
+def pyramidal_mse_with_tokens(true_heatmaps, predicted_heatmaps, tokens, nb_levels=5):
+    """
+    Compute mean squared error between two set heatmaps on a pyramidal representation.
+
+    Parameters
+    ----------
+    true_heatmaps : tf.Tensor
+        The true heatmaps.
+    predicted_heatmaps : tf.Tensor
+        The predicted heatmaps.
+    tokens : tf.Tensor
+        The tokens to weight the MSE.
+    nb_levels : int
+        The number of levels to use in the pyramid.
+
+    Returns
+    -------
+    tf.Tensor
+        The weighted MSE.
+
+    """
+    pyramid_y     = pyramidal_representation(true_heatmaps[:, :, :, None], nb_levels)
+    pyramid_y_pred = pyramidal_representation(predicted_heatmaps[:, :, :, None], nb_levels)
+
+    loss = tf.reduce_mean([
+                            _mse_with_tokens(pyramid_y[i], pyramid_y_pred[i], tokens)
+                            for i in range(nb_levels)])
+
+    return loss
+
+
+def harmonizer_loss(model, images, tokens, labels, true_heatmaps,
+                    cross_entropy = Cross_entropy, lambda_weights=1e-5, lambda_harmonization=1.0):
+    """
+    Compute the harmonization loss: cross entropy + pyramidal mse of standardized-cut heatmaps.
+
+    Parameters
+    ----------
+    model : tf.keras.Model
+        The model to train.
+    images : tf.Tensor
+        The batch of images to train on.
+    tokens : tf.Tensor
+        The batch of tokens to weight the MSE.
+    labels : tf.Tensor
+        The batch of labels.
+    true_heatmaps : tf.Tensor
+        The batch of true heatmaps (e.g Click-me maps) to align the model on.
+    cross_entropy : tf.keras.losses.Loss
+        The cross entropy loss to use.
+
+    Returns
+    -------
+    gradients : tf.Tensor
+        The gradients on the given batch according to the harmonization loss.
+    """
+    with tf.GradientTape() as tape:
+        tape.watch(images)
+        tape.watch(model.trainable_variables)
+
+        with tf.GradientTape() as tape_metapred:
+            tape_metapred.watch(images)
+            tape_metapred.watch(model.trainable_variables)
+
+            y_pred = model(images, training=True)
+            loss_metapred = tf.reduce_sum(y_pred * labels, -1)
+
+        # compute the saliency maps
+        sa_maps = tf.cast(tape_metapred.gradient(loss_metapred, images), tf.float32)
+        sa_maps = tf.reduce_mean(sa_maps, -1)
+        # apply the standardization-cut procedure on heatmaps
+        sa_maps_preprocess = standardize_cut(sa_maps)
+        heatmaps_preprocess = standardize_cut(true_heatmaps)
+
+        # re-normalize before pyramidal
+        _hm_max = tf.math.reduce_max(heatmaps_preprocess, (1, 2), keepdims=True) + 1e-6
+        _sa_max = tf.stop_gradient(tf.math.reduce_max(sa_maps_preprocess, (1, 2),
+                                                keepdims=True))  + 1e-6
+        # normalize the true heatmaps according to the saliency maps
+        heatmaps_preprocess = heatmaps_preprocess / _hm_max * _sa_max
+
+        # compute and combine the losses
+        harmonization_loss = pyramidal_mse_with_tokens(sa_maps_preprocess,
+                                                       heatmaps_preprocess, tokens)
+        cce_loss = tf.reduce_mean(cross_entropy(labels, y_pred))
+        weight_loss = tf.add_n([tf.nn.l2_loss(v)
+                                for v in model.trainable_variables \
+                                if 'bn/' not in v.name
+                                and 'normalization' not in v.name
+                                and 'embed' not in v.name
+                                and 'Norm' not in v.name
+                                and 'norm' not in v.name
+                                and 'class_token' not in v.name
+                                ])
+
+        loss = tf.cast(cce_loss, tf.float32) + \
+               tf.cast(weight_loss * lambda_weights, tf.float32) + \
+               tf.cast(harmonization_loss * lambda_harmonization, tf.float32)
+
+    gradients = tape.gradient(loss, model.trainable_variables)
+
+    return gradients

--- a/harmonization/training/pyramid.py
+++ b/harmonization/training/pyramid.py
@@ -1,0 +1,44 @@
+"""
+Module related to the Pyramidal representation
+"""
+
+import numpy as np
+import tensorflow as tf
+
+
+def _downsample(image,
+                kernel):
+    return tf.nn.conv2d(
+        input=image, filters=kernel, strides=[1, 2, 2, 1], padding="SAME")
+
+
+def _binomial_kernel(num_channels):
+    kernel = np.array((1., 4., 6., 4., 1.), dtype=np.float32)
+    kernel = np.outer(kernel, kernel)
+    kernel /= np.sum(kernel)
+    kernel = kernel[:, :, np.newaxis, np.newaxis]
+    return tf.constant(kernel, dtype=tf.float32) * tf.eye(num_channels, dtype=tf.float32)
+
+
+def pyramidal_representation(image, num_levels):
+    """
+    Compute the pyramidal representation of an image.
+
+    Parameters
+    ----------
+    image : tf.Tensor
+        The image to compute the pyramidal representation.
+    num_levels : int
+        The number of levels to use in the pyramid.
+
+    Returns
+    -------
+    list of tf.Tensor
+        The pyramidal representation.
+    """
+    kernel = _binomial_kernel(tf.shape(input=image)[3])
+    levels = [image]
+    for _ in range(num_levels):
+        image = _downsample(image, kernel)
+        levels.append(image)
+    return levels

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('requirements.txt', encoding="utf-8") as requirements_file:
 
 setup(
     name="Harmonization",
-    version="0.0.1",
+    version="0.0.2",
     description="Aligning Human & Machine vision",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,10 @@
 from setuptools import setup, find_packages
 
-with open("README.md", encoding="utf-8") as fh:
-    README = fh.read()
+with open("README.md", encoding="utf-8") as readme_file:
+    README = readme_file.read()
+
+with open('requirements.txt', encoding="utf-8") as requirements_file:
+    REQUIREMENTS = requirements_file.read().splitlines()
 
 setup(
     name="Harmonization",
@@ -12,8 +15,7 @@ setup(
     author="Thomas FEL",
     author_email="thomas_fel@brown.edu",
     license="MIT",
-    install_requires=['tensorflow>=2.1.0', 'numpy', 'scikit-learn', 'scikit-image',
-                      'matplotlib', 'scipy', 'opencv-python'],
+    install_requires=REQUIREMENTS,
     extras_require={
         "tests": ["pytest", "pylint"],
         "docs": ["mkdocs", "mkdocs-material", "numkdoc"],

--- a/tests/training/test_loss.py
+++ b/tests/training/test_loss.py
@@ -1,0 +1,58 @@
+import tensorflow as tf
+import numpy as np
+from harmonization.training import (standardize_cut,
+                                    pyramidal_mse_with_tokens,
+                                    harmonizer_loss)
+from ..utils import almost_equal
+
+
+def test_standardize_cut():
+    """
+    Test the standardize_cut function
+    """
+    heatmaps = tf.random.uniform((10, 224, 224))
+
+    preprocessed_heatmaps = standardize_cut(heatmaps)
+
+    assert preprocessed_heatmaps.shape == (10, 224, 224)
+    assert tf.reduce_min(preprocessed_heatmaps) >= 0.0
+
+
+def test_pyramidal_mse_with_tokens():
+    """
+    Test the pyramidal_mse_with_tokens function
+    """
+    heatmaps = tf.random.uniform((10, 224, 224))
+    predicted_heatmaps = tf.random.uniform((10, 224, 224))
+    tokens = tf.random.uniform((10,))
+
+    loss = pyramidal_mse_with_tokens(heatmaps, predicted_heatmaps, tokens)
+
+    assert isinstance(loss, tf.Tensor)
+    assert loss.shape == ()
+
+    loss_none = pyramidal_mse_with_tokens(heatmaps, predicted_heatmaps, tf.zeros((10,)))
+    assert almost_equal(loss_none, 0.0)
+
+    loss_all = pyramidal_mse_with_tokens(heatmaps, predicted_heatmaps, tf.ones((10,)))
+    assert loss_all >= loss >= loss_none
+
+
+def test_harmonizer_loss():
+    """
+    Test the harmonizer_loss function
+    """
+    images = tf.random.uniform((10, 224, 224, 3))
+    tokens = tf.random.uniform((10,))
+    labels = tf.random.uniform((10, 10))
+    true_heatmaps = tf.random.uniform((10, 224, 224))
+
+    model = tf.keras.Sequential([
+        tf.keras.layers.InputLayer(input_shape=(224, 224, 3)),
+        tf.keras.layers.MaxPooling2D((10, 10), strides=(10, 10)),
+        tf.keras.layers.Flatten(),
+        tf.keras.layers.Dense(10, activation='linear')
+    ])
+
+    gradients = harmonizer_loss(model, images, tokens, labels, true_heatmaps)
+    assert len(gradients) == len(model.trainable_variables)


### PR DESCRIPTION
# Introduce Harmonization loss & prepare for tutorial on training harmonized models

This commits introduce the harmonizer training loss and prepare the introduction of a notebook/tutorial to easily train an harmonized model on tpus. 

d79074af75dc8ebced9114437f300174d2aab9d6 fix an issue: the website now fetch only 100 examples to avoid freezing issue on some browser.

04567fb97f3e5e2282b874aea931f35fdc463066 introduce the harmonization loss and associated tests.

ced81779079d30fd1f53658a9c02c67cb627690b bind all the libraries needed in the setup (needed as  we're now on pypi).