### PR TITLE
requirements: fix keras-cv pip name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ scikit-image
 matplotlib
 scipy
 opencv-python
-keras_cv_attention_models
+keras-cv-attention-models


### PR DESCRIPTION
modified dependencies according discussion in https://github.com/serre-lab/Harmonization/issues/12.
I prefer to avoid forcing Tensorflow version (to avoid breaking people env that struggle with their cuda install) as the lib should work with tf < 2.10 when the model are just in eval mode :)

 big thanks to @LukasMut and @leondgarse 🎉 !